### PR TITLE
Add task queue API, revert slow turtle; all tests pass

### DIFF
--- a/index.css
+++ b/index.css
@@ -289,6 +289,15 @@ body {
   top: 5px; bottom: 35px; width: 70px;
 }
 
+#run, #stop {
+  top: 5px; bottom: 35px; width: 70px;
+}
+
+#run { display: block; }
+#stop { display: none; }
+.running #run { display: none; }
+.running #stop { display: block; }
+
 #clear {
   height: 19px; bottom: 10px; width: 70px;
 }

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
 <div id="input-panel" class="panel">
   <!-- TODO: Make this a button or anchor -->
   <div id="run"><div data-l10n-id="ip-button-run" class="label">Run</div></div>
-  <div id="stop" style="display: none"><div data-l10n-id="ip-button-stop" class="label">Stop</div></div>
+  <div id="stop"><div data-l10n-id="ip-button-stop" class="label">Stop</div></div>
   <div id="clear"><div data-l10n-id="ip-button-clear" class="label">Clear</div></div>
   <div id="input">
     <div class="inner">

--- a/index.js
+++ b/index.js
@@ -209,21 +209,20 @@ function initInput() {
       input.setValue('');
     }
     setTimeout(function() {
-      setRun(false);
-      logo.run(v).then(function () {
-        setRun(true);
-      }).catch(function (e) {
+      document.body.classList.add('running');
+      logo.run(v).catch(function (e) {
         error.innerHTML = '';
         error.appendChild(document.createTextNode(e.message));
         error.classList.add('shown');
-        setRun(true);
+      }).then(function() {
+        document.body.classList.remove('running');
       });
     }, 100);
   }
 
   function stop() {
     logo.bye();
-    setRun(true);
+    document.body.classList.remove('running');
   }
 
   input.run = run;
@@ -369,16 +368,6 @@ function initInput() {
   $('#run').addEventListener('click', run);
   $('#stop').addEventListener('click', stop);
   $('#clear').addEventListener('click', clear);
-
-  function setRun(canRun) {
-    if (canRun) {
-      $('#run').style.display = '';
-      $('#stop').style.display = 'none';
-    } else {
-      $('#run').style.display = 'none';
-      $('#stop').style.display = '';
-    }
-  }
 
   window.addEventListener('message', function(e) {
     if ('example' in e.data) {

--- a/language.html
+++ b/language.html
@@ -913,6 +913,9 @@ of comparison.</p>
   <dt><code>op <var>expr</var></code>
   <dd>End the running procedure and output the specified value
 
+  <dt><code>wait <var>time</var></code>
+  <dd>Pauses execution. <var>time</var> is in 60ths of a second.
+
   <dt><code>bye</code>
   <dd>Terminate the program
 

--- a/logo.js
+++ b/logo.js
@@ -20,6 +20,8 @@
 function LogoInterpreter(turtle, stream, savehook)
 //----------------------------------------------------------------------
 {
+  'use strict';
+
   var self = this;
 
   var UNARY_MINUS = '<UNARYMINUS>'; // Must not match regexIdentifier

--- a/logo.js
+++ b/logo.js
@@ -892,8 +892,10 @@ function LogoInterpreter(turtle, stream, savehook)
           reject(new Bye);
           return;
         }
-        if (!statements.length)
+        if (!statements.length) {
           resolve(lastResult);
+          return;
+        }
         Promise.resolve(evaluateExpression(statements))
           .then(function(result) {
             if (result !== undefined && !options.returnResult) {

--- a/logo.js
+++ b/logo.js
@@ -1704,7 +1704,7 @@ function LogoInterpreter(turtle, stream, savehook)
     if (!args.length)
       return Promise.resolve(defaultValue);
     return new Promise(function(resolve, reject) {
-      (function runLoop() {
+      (function loop() {
         var r = args.shift()();
         if (!args.length) {
           resolve(r);
@@ -1715,7 +1715,7 @@ function LogoInterpreter(turtle, stream, savehook)
             resolve(value);
             return;
           }
-          runLoop();
+          loop();
         });
       }());
     });
@@ -2498,7 +2498,7 @@ function LogoInterpreter(turtle, stream, savehook)
       count = aexpr(count);
       statements = reparse(lexpr(statements));
       var i = 1;
-      function runLoop() {
+      (function loop() {
         if (i > count) {
           resolve();
           return;
@@ -2506,9 +2506,8 @@ function LogoInterpreter(turtle, stream, savehook)
         self.repcount = i;
         i++;
         var result = self.execute(statements);
-        result.then(runLoop, reject);
-      }
-      runLoop();
+        result.then(loop, reject);
+      }());
     }), function () {
       self.repcount = old_repcount;
     });
@@ -2518,16 +2517,15 @@ function LogoInterpreter(turtle, stream, savehook)
     statements = reparse(lexpr(statements));
     return new Promise(function (resolve, reject) {
       var i = 1;
-      function runLoop() {
+      (function loop() {
         var old_repcount = self.repcount;
         self.repcount = i;
         i++;
         var result = self.execute(statements);
         promiseFinally(result, function () {
           self.repcount = old_repcount;
-        }).then(runLoop, reject);
-      }
-      runLoop();
+        }).then(loop, reject);
+      }());
     });
   });
 
@@ -2625,7 +2623,7 @@ function LogoInterpreter(turtle, stream, savehook)
       })
       .then(function() {
         return new Promise(function(resolve, reject) {
-          function runLoop() {
+          (function loop() {
             if (sign(current - limit) === sign(step)) {
               resolve();
               return;
@@ -2639,11 +2637,10 @@ function LogoInterpreter(turtle, stream, savehook)
               .then(function(result) {
                 step = aexpr(result);
                 current += step;
-                runLoop();
+                loop();
               })
-            .catch(reject);
-          }
-          runLoop();
+              .catch(reject);
+          }());
         });
       });
   });
@@ -2814,16 +2811,15 @@ function LogoInterpreter(turtle, stream, savehook)
     list = lexpr(list);
     var index = 0;
     return new Promise(function (resolve, reject) {
-      function runLoop() {
+      (function loop() {
         if (index >= list.length) {
           resolve();
           return;
         }
         var result = Promise.resolve(routine(list[index]));
         index++;
-        result.then(runLoop, reject);
-      }
-      runLoop();
+        result.then(loop, reject);
+      }());
     });
   });
 
@@ -2844,7 +2840,7 @@ function LogoInterpreter(turtle, stream, savehook)
     var mapped = [];
     var index = 0;
     return new Promise(function (resolve, reject) {
-      function runLoop() {
+      (function loop() {
         if (index >= list.length) {
           resolve(mapped);
           return;
@@ -2853,10 +2849,9 @@ function LogoInterpreter(turtle, stream, savehook)
         index++;
         result.then(function (value) {
           mapped.push(value);
-          runLoop();
+          loop();
         }, reject);
-      }
-      runLoop();
+      }());
     });
   });
 
@@ -2878,7 +2873,7 @@ function LogoInterpreter(turtle, stream, savehook)
     var filtered = [];
     var index = 0;
     return new Promise(function (resolve, reject) {
-      function runLoop() {
+      (function loop() {
         if (index >= list.length) {
           resolve(filtered);
           return;
@@ -2890,10 +2885,9 @@ function LogoInterpreter(turtle, stream, savehook)
           if (value) {
             filtered.push(item);
           }
-          runLoop();
+          loop();
         }, reject);
-      }
-      runLoop();
+      }());
     });
   });
 
@@ -2912,7 +2906,7 @@ function LogoInterpreter(turtle, stream, savehook)
     list = lexpr(list);
     var index = 0;
     return new Promise(function (resolve, reject) {
-      function runLoop() {
+      (function loop() {
         if (index >= list.length) {
           resolve([]);
           return;
@@ -2923,12 +2917,11 @@ function LogoInterpreter(turtle, stream, savehook)
         result.then(function (value) {
           if (value) {
             resolve(item);
-          } else {
-            runLoop();
+            return;
           }
+          loop();
         }, reject);
-      }
-      runLoop();
+      }());
     });
   });
 

--- a/logo.js
+++ b/logo.js
@@ -2916,24 +2916,20 @@ function LogoInterpreter(turtle, stream, savehook)
                              { name: procname }));
     }
 
-    if (!list.length)
-      return value;
-
     return new Promise(function(resolve, reject) {
       (function loop() {
+        if (!list.length) {
+          resolve(value);
+          return;
+        }
         var next = list.shift();
         Promise.resolve(procedure(value, next))
           .then(function(result) {
-            if (!list.length) {
-              resolve(result);
-              return;
-            }
             value = result;
             loop();
           }, reject);
       }());
     });
-
   });
 
   // Not Supported: crossmap

--- a/logo.js
+++ b/logo.js
@@ -2584,6 +2584,12 @@ function LogoInterpreter(turtle, stream, savehook)
   // Not Supported: continue
   // Not Supported: wait
 
+  def("wait", function(time) {
+    return new Promise(function(resolve) {
+      setTimeout(resolve, aexpr(time) / 60 * 1000);
+    });
+  });
+
   def("bye", function() {
     throw new Bye;
   });

--- a/logo.js
+++ b/logo.js
@@ -106,13 +106,13 @@ function LogoInterpreter(turtle, stream, savehook)
     return promise.then(
       function(result) {
         return Promise.resolve(finalBlock()).then(
-          function () {
+          function() {
             return result;
           });
       },
       function(err) {
         return Promise.resolve(finalBlock()).then(
-          function () {
+          function() {
             throw err;
           });
       });
@@ -602,7 +602,7 @@ function LogoInterpreter(turtle, stream, savehook)
   // applies the function to the results.
   function defer(func /*, input...*/) {
     var input = Array.prototype.slice.call(arguments, 1);
-    return function () {
+    return function() {
       return serialExecute(input.slice())
         .then(function(args) {
           return func.apply(null, args);
@@ -1094,11 +1094,11 @@ function LogoInterpreter(turtle, stream, savehook)
         scope.set(inputs[i], {value: arguments[i]});
       }
       self.scopes.push(scope);
-      return promiseFinally(self.execute(block).then(null, function (err) {
+      return promiseFinally(self.execute(block).then(null, function(err) {
         if (err instanceof Output)
           return err.output;
         throw err;
-      }), function () {
+      }), function() {
         self.scopes.pop();
       });
     };
@@ -1684,12 +1684,12 @@ function LogoInterpreter(turtle, stream, savehook)
 
   def("and", function(a, b) {
     var args = Array.from(arguments);
-    return _checker(args, function (value) {return !value;}, 1);
+    return _checker(args, function(value) {return !value;}, 1);
   }, {noeval: true});
 
   def("or", function(a, b) {
     var args = Array.from(arguments);
-    return _checker(args, function (value) {return value;}, 0);
+    return _checker(args, function(value) {return value;}, 0);
   }, {noeval: true});
 
   function _checker(args, shouldStop, defaultValue) {
@@ -1795,7 +1795,7 @@ function LogoInterpreter(turtle, stream, savehook)
     turtle.beginpath();
     return promiseFinally(
       self.execute(statements),
-      function () {
+      function() {
         turtle.fillpath(fillcolor);
       });
   });
@@ -2023,7 +2023,7 @@ function LogoInterpreter(turtle, stream, savehook)
     }
 
     var result = [];
-    plist.forEach(function (key, value) {
+    plist.forEach(function(key, value) {
       result.push(key);
       result.push(copy(value));
     });
@@ -2130,7 +2130,7 @@ function LogoInterpreter(turtle, stream, savehook)
 
   def("globals", function() {
     var globalscope = self.scopes[0];
-    return globalscope.keys().filter(function (x) {
+    return globalscope.keys().filter(function(x) {
       return !globalscope.get(x).buried;
     });
   });
@@ -2244,7 +2244,7 @@ function LogoInterpreter(turtle, stream, savehook)
 
     self.plists.keys().filter(function(x) {
       return !self.plists.get(x).buried;
-    }).forEach(function (name) {
+    }).forEach(function(name) {
       self.plists['delete'](name);
     });
   });
@@ -2271,7 +2271,7 @@ function LogoInterpreter(turtle, stream, savehook)
   def("erpls", function() {
     self.plists.keys().filter(function(x) {
       return !self.plists.get(x).buried;
-    }).forEach(function (key) {
+    }).forEach(function(key) {
       self.plists['delete'](key);
     });
   });
@@ -2499,7 +2499,7 @@ function LogoInterpreter(turtle, stream, savehook)
         self.execute(statements)
           .then(loop, reject);
       }());
-    }), function () {
+    }), function() {
       self.repcount = old_repcount;
     });
   });
@@ -2683,12 +2683,12 @@ function LogoInterpreter(turtle, stream, savehook)
   }
 
   def("do.until", function(block, tf) {
-    var nottf = function () { return notpromise(tf); };
+    var nottf = function() { return notpromise(tf); };
     return self.routines.get("do.while")(block, nottf);
   }, {noeval: true});
 
   def("until", function(tf, block) {
-    var nottf = function () { return notpromise(tf); };
+    var nottf = function() { return notpromise(tf); };
     return self.routines.get("while")(nottf, block);
   }, {noeval: true});
 
@@ -2793,7 +2793,7 @@ function LogoInterpreter(turtle, stream, savehook)
                              { name: procname }));
     }
     list = lexpr(list);
-    return new Promise(function (resolve, reject) {
+    return new Promise(function(resolve, reject) {
       (function loop() {
         if (!list.length) {
           resolve();
@@ -2820,14 +2820,14 @@ function LogoInterpreter(turtle, stream, savehook)
 
     list = lexpr(list);
     var mapped = [];
-    return new Promise(function (resolve, reject) {
+    return new Promise(function(resolve, reject) {
       (function loop() {
         if (!list.length) {
           resolve(mapped);
           return;
         }
         Promise.resolve(routine(list.shift()))
-          .then(function (value) {
+          .then(function(value) {
             mapped.push(value);
             loop();
           }, reject);
@@ -2881,7 +2881,7 @@ function LogoInterpreter(turtle, stream, savehook)
     }
 
     list = lexpr(list);
-    return new Promise(function (resolve, reject) {
+    return new Promise(function(resolve, reject) {
       (function loop() {
         if (!list.length) {
           resolve([]);
@@ -2889,7 +2889,7 @@ function LogoInterpreter(turtle, stream, savehook)
         }
         var item = list.shift();
         var result = Promise.resolve(routine(item));
-        result.then(function (value) {
+        result.then(function(value) {
           if (value) {
             resolve(item);
             return;

--- a/logo.js
+++ b/logo.js
@@ -2796,7 +2796,7 @@ function LogoInterpreter(turtle, stream, savehook)
     return promiseLoop(function(loop, resolve, reject) {
       if (!list.length) {
         resolve();
-          return;
+        return;
       }
       Promise.resolve(routine(list.shift()))
         .then(loop, reject);
@@ -2881,13 +2881,13 @@ function LogoInterpreter(turtle, stream, savehook)
         return;
       }
       var item = list.shift();
-      var result = Promise.resolve(routine(item));
-      result.then(function(value) {
-        if (value) {
-          resolve(item);
-          return;
-        }
-        loop();
+      Promise.resolve(routine(item))
+        .then(function(value) {
+          if (value) {
+            resolve(item);
+            return;
+          }
+          loop();
       }, reject);
     });
   });
@@ -2911,8 +2911,7 @@ function LogoInterpreter(turtle, stream, savehook)
         resolve(value);
         return;
       }
-      var next = list.shift();
-      Promise.resolve(procedure(value, next))
+      Promise.resolve(procedure(value, list.shift()))
         .then(function(result) {
           value = result;
           loop();

--- a/logo.js
+++ b/logo.js
@@ -884,9 +884,7 @@ function LogoInterpreter(turtle, stream, savehook)
     // Operate on a copy so the original is not destroyed
     statements = statements.slice();
 
-    if (!statements.length)
-      return Promise.resolve();
-
+    var lastResult;
     return new Promise(function(resolve, reject) {
       (function loop() {
         if (self.forceBye) {
@@ -894,16 +892,15 @@ function LogoInterpreter(turtle, stream, savehook)
           reject(new Bye);
           return;
         }
+        if (!statements.length)
+          resolve(lastResult);
         Promise.resolve(evaluateExpression(statements))
           .then(function(result) {
             if (result !== undefined && !options.returnResult) {
               reject(new Error(format(__("Don't know what to do with {result}"), {result: result})));
               return;
             }
-            if (!statements.length) {
-              resolve(result);
-              return;
-            }
+            lastResult = result;
             loop();
           }, reject);
       }());

--- a/logo.js
+++ b/logo.js
@@ -94,7 +94,7 @@ function LogoInterpreter(turtle, stream, savehook)
           .then(function(result) {
             results.push(result);
             loop();
-          }).catch(reject);
+          }, reject);
       }());
     });
   }
@@ -2635,8 +2635,7 @@ function LogoInterpreter(turtle, stream, savehook)
                 step = aexpr(result);
                 current += step;
                 loop();
-              })
-              .catch(reject);
+              }, reject);
           }());
         });
       });
@@ -2665,8 +2664,7 @@ function LogoInterpreter(turtle, stream, savehook)
               return;
             }
             loop();
-          })
-          .catch(reject);
+          }, reject);
       }());
     });
   }, {noeval: true});
@@ -2683,12 +2681,10 @@ function LogoInterpreter(turtle, stream, savehook)
             }
             self.execute(block)
               .then(loop);
-          })
-          .catch(reject);
+          }, reject);
       }());
     });
   }, {noeval: true});
-
 
   function notpromise(tf) {
     return Promise.resolve(tf()).then(function(r) { return !r; });
@@ -2742,8 +2738,7 @@ function LogoInterpreter(turtle, stream, savehook)
               return;
             }
             loop();
-          })
-          .catch(reject);
+          }, reject);
       }());
     });
   });
@@ -2806,16 +2801,14 @@ function LogoInterpreter(turtle, stream, savehook)
                              { name: procname }));
     }
     list = lexpr(list);
-    var index = 0;
     return new Promise(function (resolve, reject) {
       (function loop() {
-        if (index >= list.length) {
+        if (!list.length) {
           resolve();
           return;
         }
-        var result = Promise.resolve(routine(list[index]));
-        index++;
-        result.then(loop, reject);
+        Promise.resolve(routine(list.shift()))
+          .then(loop, reject);
       }());
     });
   });
@@ -2835,19 +2828,17 @@ function LogoInterpreter(turtle, stream, savehook)
 
     list = lexpr(list);
     var mapped = [];
-    var index = 0;
     return new Promise(function (resolve, reject) {
       (function loop() {
-        if (index >= list.length) {
+        if (!list.length) {
           resolve(mapped);
           return;
         }
-        var result = Promise.resolve(routine(list[index]));
-        index++;
-        result.then(function (value) {
-          mapped.push(value);
-          loop();
-        }, reject);
+        Promise.resolve(routine(list.shift()))
+          .then(function (value) {
+            mapped.push(value);
+            loop();
+          }, reject);
       }());
     });
   });
@@ -2880,8 +2871,7 @@ function LogoInterpreter(turtle, stream, savehook)
             if (value)
               filtered.push(item);
             loop();
-          })
-          .catch(reject);
+          }, reject);
       }());
     });
   });
@@ -2899,16 +2889,14 @@ function LogoInterpreter(turtle, stream, savehook)
     }
 
     list = lexpr(list);
-    var index = 0;
     return new Promise(function (resolve, reject) {
       (function loop() {
-        if (index >= list.length) {
+        if (!list.length) {
           resolve([]);
           return;
         }
-        var item = list[index];
+        var item = list.shift();
         var result = Promise.resolve(routine(item));
-        index++;
         result.then(function (value) {
           if (value) {
             resolve(item);

--- a/tests.js
+++ b/tests.js
@@ -95,14 +95,14 @@ QUnit.module("Logo Unit Tests", {
       this.stream.clear();
       var result = this.interpreter.run(expression, {returnResult: true});
       var done = t.async();
-      result.then(function () {
+      result.then((function () {
         var actual = this.stream.last_prompt;
         this.stream.clear();
         t.equal(actual, expected, expression);
-      }, function (err) {
+      }).bind(this), (function (err) {
         t.equal("(no error)", err, expression);
         this.stream.clear();
-      }).then(done);
+      }).bind(this)).then(done);
     };
 
     this.assert_predicate = function(expression, predicate) {
@@ -499,7 +499,7 @@ QUnit.test("Data Structure Primitives", function(t) {
   this.assert_equals('standout "whatever', 'whatever');
 });
 
-if (false) QUnit.test("Communication", function(t) {
+QUnit.test("Communication", function(t) {
   t.expect(22);
 
   // 3.1 Transmitters
@@ -524,10 +524,14 @@ if (false) QUnit.test("Communication", function(t) {
 
   // 3.2 Receivers
 
-  this.stream.inputbuffer = "test";
+  this.interpreter.queueTask((function() {
+    this.stream.inputbuffer = "test";
+  }).bind(this));
   this.assert_equals('readword', 'test');
 
-  this.stream.inputbuffer = "a b c 1 2 3";
+  this.interpreter.queueTask((function() {
+    this.stream.inputbuffer = "a b c 1 2 3";
+  }).bind(this));
   this.assert_equals('readword', 'a b c 1 2 3');
 
   this.assert_prompt('readword', undefined);

--- a/tests.js
+++ b/tests.js
@@ -1062,7 +1062,7 @@ QUnit.test("Workspace Management", function(t) {
 });
 
 QUnit.test("Control Structures", function(t) {
-  t.expect(67);
+  t.expect(69);
   //
   // 8.1 Control
   //
@@ -1105,6 +1105,11 @@ QUnit.test("Control Structures", function(t) {
   this.assert_error('test 2 > 1  show iffalse [ "a ]', 'No output from procedure');
 
   this.assert_equals('to foo forever [ if repcount = 5 [ make "c 234 stop ] ] end  foo  :c', 234);
+
+  var now;
+  this.queue(function() { now = Date.now(); });
+  this.assert_equals('wait 60/6', undefined);
+  this.queue(function() { t.ok((Date.now() - now) > (1000/6)); });
 
   this.assert_equals('forever [ if repcount = 5 [ bye ] ]', undefined);
 

--- a/tests.js
+++ b/tests.js
@@ -1062,7 +1062,7 @@ QUnit.test("Workspace Management", function(t) {
 });
 
 QUnit.test("Control Structures", function(t) {
-  t.expect(58);
+  t.expect(67);
   //
   // 8.1 Control
   //
@@ -1154,17 +1154,35 @@ QUnit.test("Control Structures", function(t) {
   // 8.2 Template-based Iteration
   //
 
+  this.interpreter.run("to add_async :a :b output .promise :a + :b end");
+  this.interpreter.run("to numberp_async :a output .promise numberp :a end");
+
   this.assert_equals('apply "word ["a "b "c]', '"a"b"c');
+  this.assert_equals('apply "add_async [1 2]', 3);
+
   this.assert_equals('invoke "word "a', 'a');
   this.assert_equals('(invoke "word "a "b "c)', 'abc');
   this.assert_equals('(invoke "word)', '');
+  this.assert_equals('(invoke "add_async 1 2)', 3);
+
   this.assert_equals('make "x 0  to addx :a make "x :x+:a end  foreach "addx [ 1 2 3 4 5 ]  :x', 15);
+  this.assert_equals('make "x 0  to addx :a make "x .promise :x+:a end  foreach "addx [ 1 2 3 4 5 ]  :x', 15);
+
   this.assert_equals('to double :x output :x * 2 end  map "double [ 1 2 3 ]', [2, 4, 6]);
+  this.assert_equals('to double :x output .promise :x * 2 end  map "double [ 1 2 3 ]', [2, 4, 6]);
+
   this.assert_equals('to odd :x output :x % 2 end  filter "odd [ 1 2 3 ]', ["1", "3"]);
+  this.assert_equals('to odd :x output .promise :x % 2 end  filter "odd [ 1 2 3 ]', ["1", "3"]);
+
   this.assert_equals('find "numberp (list "a "b "c 4 "e "f )', 4);
   this.assert_equals('find "numberp (list "a "b "c "d "e "f )', []);
+  this.assert_equals('find "numberp_async (list "a "b "c 4 "e "f )', 4);
+  this.assert_equals('find "numberp_async (list "a "b "c "d "e "f )', []);
+
   this.assert_equals('reduce "sum [ 1 2 3 4 ]', 10);
   this.assert_equals('(reduce "sum [ 1 2 3 4 ] 10)', 20);
+  this.assert_equals('reduce "add_async [ 1 2 3 4 ]', 10);
+  this.assert_equals('(reduce "add_async [ 1 2 3 4 ] 10)', 20);
 
   // TODO: Order of operations
   // TODO: Structures, lists of lists

--- a/tests.js
+++ b/tests.js
@@ -768,12 +768,13 @@ QUnit.test("Logical Operations", function(t) {
   this.assert_stream('or 0 (type "yup)', 'yup');
 });
 
-if (false) QUnit.test("Graphics", function(t) {
+QUnit.test("Graphics", function(t) {
   t.expect(69);
 
   // NOTE: test canvas is 300,300 (so -150...150 coordinates before hitting)
   // edge
 
+  this.interpreter.run('setspeed Infinity');
   this.interpreter.run('clearscreen');
   this.assert_equals('clean home (list heading xcor ycor)', [0, 0, 0]);
 
@@ -824,11 +825,9 @@ if (false) QUnit.test("Graphics", function(t) {
   this.assert_equals('setpos [ 12 34 ] clean pos', [12, 34]);
   this.assert_equals('setpos [ 12 34 ] clearscreen (list heading xcor ycor)', [0, 0, 0]);
   this.assert_equals('setpos [ 12 34 ] cs (list heading xcor ycor)', [0, 0, 0]);
-
   this.assert_equals('wrap turtlemode', 'WRAP');
 
   this.assert_equals('setxy 0 0 setxy 160 160 (list xcor ycor)', [-140, -140]);
-
   this.assert_equals('window turtlemode', 'WINDOW');
   this.assert_equals('setxy 0 0 setxy 160 160 (list xcor ycor)', [160, 160]);
 
@@ -1063,7 +1062,7 @@ QUnit.test("Workspace Management", function(t) {
 });
 
 QUnit.test("Control Structures", function(t) {
-  //t.expect(58);
+  t.expect(58);
   //
   // 8.1 Control
   //

--- a/turtle.js
+++ b/turtle.js
@@ -313,7 +313,7 @@ function CanvasTurtle(canvas_ctx, turtle_ctx, width, height) {
     }
   };
 
-  this.getstate = function () {
+  this.getstate = function() {
     return {
       isturtlestate: true,
       color: this.getcolor(),
@@ -328,7 +328,7 @@ function CanvasTurtle(canvas_ctx, turtle_ctx, width, height) {
     };
   };
 
-  this.setstate = function (state) {
+  this.setstate = function(state) {
     if ((! state) || ! state.isturtlestate) {
       throw new Error("Tried to restore a state that is not a turtle state");
     }

--- a/turtle.js
+++ b/turtle.js
@@ -25,7 +25,7 @@ function CanvasTurtle(canvas_ctx, turtle_ctx, width, height) {
 
   var self = this;
 
-  self.speed = 3;
+  self.speed = 50;
   self.speed_interval = 25;
 
   function moveto(x, y, fast) {

--- a/turtle.js
+++ b/turtle.js
@@ -17,6 +17,7 @@
 // limitations under the License.
 
 function CanvasTurtle(canvas_ctx, turtle_ctx, width, height) {
+  'use strict';
   width = Number(width);
   height = Number(height);
 
@@ -24,48 +25,8 @@ function CanvasTurtle(canvas_ctx, turtle_ctx, width, height) {
   function rad2deg(r) { return r * 180 / Math.PI; }
 
   var self = this;
-
-  self.speed = 50;
-  self.speed_interval = 25;
-
-  function moveto(x, y, fast) {
-    if (! (self.down || self.filling)) {
-      fast = true;
-    }
+  function moveto(x, y) {
     function _go(x1, y1, x2, y2) {
-      if (fast) {
-        return Promise.resolve(_goLine(x1, y1, x2, y2));
-      }
-      var posx = x1;
-      var posy = y1;
-      var steps = Math.floor(Math.sqrt(Math.pow(x1-x2, 2)+Math.pow(y1-y2, 2))/self.speed);
-      if (! steps) {
-        _goLine(x1, y1, x2, y2);
-        return Promise.resolve();
-      }
-      var intx = (x2-x1)/steps;
-      var inty = (y2-y1)/steps;
-      return new Promise(function (resolve, reject) {
-        var count = steps;
-        var timeout = setInterval(function () {
-          try {
-            count--;
-            _goLine(posx, posy, posx+intx, posy+inty);
-            posx += intx;
-            posy += inty;
-            if (! count) {
-              clearTimeout(timeout);
-              resolve();
-            }
-          } catch (e) {
-            clearTimeout(timeout);
-            reject(e);
-          }
-        }, self.speed_interval);
-      });
-    }
-
-    function _goLine(x1, y1, x2, y2) {
       if (self.filling) {
         canvas_ctx.lineTo(x1, y1);
         canvas_ctx.lineTo(x2, y2);
@@ -84,10 +45,10 @@ function CanvasTurtle(canvas_ctx, turtle_ctx, width, height) {
 
       switch (self.turtlemode) {
         case 'window':
-          return _go(self.x, self.y, x, y).then(function () {
-            self.x = x;
-            self.y = y;
-          });
+          _go(self.x, self.y, x, y);
+          self.x = x;
+          self.y = y;
+          return;
 
         default:
         case 'wrap':
@@ -133,22 +94,23 @@ function CanvasTurtle(canvas_ctx, turtle_ctx, width, height) {
             wy = less ? height : 0;
           }
 
-          return _go(self.x, self.y, ix, iy).then(function () {
+          _go(self.x, self.y, ix, iy);
 
-            if (self.turtlemode === 'fence') {
-              // FENCE - stop on collision
-              self.x = ix;
-              self.y = iy;
+          if (self.turtlemode === 'fence') {
+            // FENCE - stop on collision
+            self.x = ix;
+            self.y = iy;
+            return;
+          } else {
+            // WRAP - keep going
+            self.x = wx;
+            self.y = wy;
+            if (fx === 1 && fy === 1) {
               return;
-            } else {
-              // WRAP - keep going
-              self.x = wx;
-              self.y = wy;
-              if (fx === 1 && fy === 1) {
-                return;
-              }
             }
-          });
+          }
+
+          break;
       }
     }
   }
@@ -166,12 +128,12 @@ function CanvasTurtle(canvas_ctx, turtle_ctx, width, height) {
 
     x = this.x + distance * Math.cos(this.r);
     y = this.y - distance * Math.sin(this.r);
-    return moveto(x, y).then(function () {
-      if (point) {
-        this.x = saved_x;
-        this.y = saved_y;
-      }
-    });
+    moveto(x, y);
+
+    if (point) {
+      this.x = saved_x;
+      this.y = saved_y;
+    }
   };
 
   this.turn = function(angle) {
@@ -239,7 +201,7 @@ function CanvasTurtle(canvas_ctx, turtle_ctx, width, height) {
     x = (x === undefined) ? this.x : x + (width / 2);
     y = (y === undefined) ? this.y : -y + (height / 2);
 
-    return moveto(x, y);
+    moveto(x, y);
   };
 
   this.towards = function(x, y) {
@@ -254,9 +216,8 @@ function CanvasTurtle(canvas_ctx, turtle_ctx, width, height) {
   };
 
   this.clearscreen = function() {
-    return this.home(true).then((function () {
-      return this.clear();
-    }).bind(this));
+    this.home();
+    this.clear();
   };
 
   this.clear = function() {
@@ -270,10 +231,9 @@ function CanvasTurtle(canvas_ctx, turtle_ctx, width, height) {
     }
   };
 
-  this.home = function(fast) {
-    return moveto(width / 2, height / 2, fast).then(function () {
-      this.r = deg2rad(90);
-    });
+  this.home = function() {
+    moveto(width / 2, height / 2);
+    this.r = deg2rad(90);
   };
 
   this.showturtle = function() {
@@ -333,27 +293,24 @@ function CanvasTurtle(canvas_ctx, turtle_ctx, width, height) {
 
   this.arc = function(angle, radius) {
     var self = this;
-    if (this.turtlemode == 'wrap') {
-      [self.x, self.x + width, this.x - width].forEach(function(x) {
-        [self.y, self.y + height, this.y - height].forEach(function(y) {
-          if (!this.filling)
+
+    if (self.turtlemode == 'wrap') {
+      [self.x, self.x + width, self.x - width].forEach(function(x) {
+        [self.y, self.y + height, self.y - height].forEach(function(y) {
+          if (!self.filling)
             canvas_ctx.beginPath();
           canvas_ctx.arc(x, y, radius, -self.r, -self.r + deg2rad(angle), false);
-          if (!this.filling)
+          if (!self.filling)
             canvas_ctx.stroke();
         });
       });
     } else {
-      if (!this.filling)
+      if (!self.filling)
         canvas_ctx.beginPath();
-      canvas_ctx.arc(this.x, this.y, radius, -this.r, -this.r + deg2rad(angle), false);
-      if (!this.filling)
+      canvas_ctx.arc(self.x, self.y, radius, -self.r, -self.r + deg2rad(angle), false);
+      if (!self.filling)
         canvas_ctx.stroke();
     }
-  };
-
-  this.setspeed = function(pixels) {
-    this.speed = pixels;
   };
 
   this.getstate = function () {


### PR DESCRIPTION
A handful of little things:
- Tweaks the `evaluateExpression` loop so unused result is an error
- Exposes a `queueTask` method that slips an arbitrary callback into the `run` queue, so test tasks can be interleaved.

With those, all tests pass except for Graphics failures. A few were due to a lack of `.bind(this)` on functions, easily fixed once found, but the scripts were not in `"use strict"` mode which made it trickier. So I added that, and found a latent bug in `ARC`. :) With those fixed, every test passes except for an `SETXY` test that wraps. I wasn't feeling brave enough to debug the `moveto()` loop so instead I reverted the `turtle.js` change entirely for now - sorry! We can add that back in under coverage.

So... now all the tests pass. :)

Anything else you can think of that must be fixed before we merge?
